### PR TITLE
Fix bug when using the LWRP from another cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,6 @@ license 'Apache 2.0'
 description 'NSQ'
 long_description 'NSQ'
 
-version '0.1.2'
+version '0.1.3'
 
 depends 'runit'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -98,6 +98,7 @@ action :add do
       setup_block = lambda do
         runit_service service_name do
           default_logger true
+          cookbook 'nsq'
           run_template_name 'nsq'
           restart_on_update false
           action :enable


### PR DESCRIPTION
When you use the LWRP from another cookbook, you need to specify the 'cookbook' attribute, otherwise chef will not retrieve the files from the nsq cookbook. 
