### PR TITLE
Runit provider doesn't like Mash.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,6 @@ license 'Apache 2.0'
 description 'NSQ'
 long_description 'NSQ'
 
-version '0.1.2'
+version '0.1.3'
 
 depends 'runit'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -101,10 +101,10 @@ action :add do
           run_template_name 'nsq'
           restart_on_update false
           action :enable
-          options Mash.new(
+          options({
             :cmd => command,
             :user => new_resource.run_as
-          )
+          })
         end
       end
       service_provider = Chef::Provider::Service::Init


### PR DESCRIPTION
This was creating sv template files with no user and cmd. I didn't dig deeply enough to figure out why Runit doesn't like Mash, but the documentation for the hw provider specifies a Hash, so I changed it to that. 